### PR TITLE
Add Jimp to peerDeependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,5 +21,8 @@
   "bugs": {
     "url": "https://github.com/jahaanjain/meme-creator/issues"
   },
+  "peerDependencies": {
+    "jimp": "^2.0.0",
+  },
   "homepage": "https://github.com/jahaanjain/meme-creator#readme"
 }

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "url": "https://github.com/jahaanjain/meme-creator/issues"
   },
   "peerDependencies": {
-    "jimp": "^2.0.0",
+    "jimp": "^2.0.0"
   },
   "homepage": "https://github.com/jahaanjain/meme-creator#readme"
 }


### PR DESCRIPTION
It would be easier if you add ```Jimp``` to peerDependencies, this way the user will notice the package is needed.